### PR TITLE
Bitcode enabled to support latest projects

### DIFF
--- a/OpenSSL.xcodeproj/project.pbxproj
+++ b/OpenSSL.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 			baseConfigurationReference = D76C0E29217737D000BC534D /* project.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -307,6 +308,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-fembed-bitcode";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -318,6 +320,7 @@
 			baseConfigurationReference = D76C0E29217737D000BC534D /* project.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -364,6 +367,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_CFLAGS = "-fembed-bitcode";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -374,6 +378,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D7ADDD7221761FB0000EDCC4 /* openssl.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -393,7 +398,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.outercorner.OpenSSL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -401,6 +405,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D7ADDD7221761FB0000EDCC4 /* openssl.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -420,7 +425,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.outercorner.OpenSSL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -428,10 +432,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D7ADDD7221761FB0000EDCC4 /* openssl.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Manual;
 				EXECUTABLE_PREFIX = lib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -439,10 +443,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D7ADDD7221761FB0000EDCC4 /* openssl.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Manual;
 				EXECUTABLE_PREFIX = lib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/Scripts/create-xcframework.sh
+++ b/Scripts/create-xcframework.sh
@@ -5,8 +5,8 @@ PROJ_DIR="$SCRIPTS_DIR/.."
 
 XCBUILD="xcrun xcodebuild"
 
-$XCBUILD build -project "$PROJ_DIR/OpenSSL.xcodeproj" -scheme 'OpenSSL' -configuration Release -destination 'generic/platform=iOS' SYMROOT='build'
-$XCBUILD build -project "$PROJ_DIR/OpenSSL.xcodeproj" -scheme 'OpenSSL' -configuration Release -destination 'generic/platform=iOS Simulator' SYMROOT='build'
+$XCBUILD build -project "$PROJ_DIR/OpenSSL.xcodeproj" -scheme 'OpenSSL' -configuration Release -destination 'generic/platform=iOS' SYMROOT='build' -ENABLE_BITCODE=YES
+$XCBUILD build -project "$PROJ_DIR/OpenSSL.xcodeproj" -scheme 'OpenSSL' -configuration Release -destination 'generic/platform=iOS Simulator' SYMROOT='build' -ENABLE_BITCODE=YES
 $XCBUILD build -project "$PROJ_DIR/OpenSSL.xcodeproj" -scheme 'OpenSSL' -configuration Release -destination 'generic/platform=macOS' SYMROOT='build'
 
 


### PR DESCRIPTION
Hi,

**Motivation:**
In my project it was required to support bitcode for iOS platforms thus I'm here with Pull request to add support for bitcode for the OpenSSL package too.
**What was done:**
Bitcode enabled in project file, BUILD_LIBRARY_FOR_DISTRIBUTION set to YES and SKIP_INSTALL set to default (NO). Create-xcframework script updated with -ENABLE_BITCODE=YES for iOS platforms.

Thank you.